### PR TITLE
Update _pcap_ex.py

### DIFF
--- a/src/pcap/_pcap_ex.py
+++ b/src/pcap/_pcap_ex.py
@@ -15,7 +15,7 @@ from libpcap._platform import sockaddr_in
 import libpcap as _pcap
 
 if not is_windows:
-    libc = ct.cdll.LoadLibrary("/lib64/libc.so.6")
+    libc = ct.cdll.LoadLibrary("libc.so.6")
 
 
 def immediate(pcap: ct.POINTER(_pcap.pcap_t)) -> int:


### PR DESCRIPTION
Fix for Linux uses
Else unable to import pcap

https://docs.python.org/3/library/ctypes.html#loading-dynamic-link-libraries